### PR TITLE
fix: 🐛 어시스턴 뷰 수정

### DIFF
--- a/src/pages/assistant/Assistant.tsx
+++ b/src/pages/assistant/Assistant.tsx
@@ -58,13 +58,7 @@ const Assistant = () => {
         consent: data?.data?.data?.isConsent,
       });
     }
-  }, [
-    isLoading,
-    data,
-    setCounseleeConsent,
-    navigate,
-    detail?.counselSessionId,
-  ]);
+  }, [isLoading, data, setCounseleeConsent, navigate, detail]);
 
   const columns: GridColDef[] = [
     {

--- a/src/pages/assistant/AssistantInfo.tsx
+++ b/src/pages/assistant/AssistantInfo.tsx
@@ -10,9 +10,14 @@ import IndependentInfo from '@/pages/assistant/tabs/IndependentInfo';
 import { useEffect, useState } from 'react';
 import { useDetailCounselSessionStore } from '@/store/counselSessionStore';
 import { useSelectCounseleeInfo } from '@/hooks/useCounseleeQuery';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useNavigationType, useParams } from 'react-router-dom';
 import { CounselAssistantDialogTypes } from './constants/modal';
 import SaveCounselAsstaint from './dialogs/SaveCounselAsstaint';
+import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
+import {
+  counselAssistantType,
+  useCounselAssistantStore,
+} from '@/store/counselAssistantStore';
 
 const TabTitle = ({
   text,
@@ -72,20 +77,29 @@ const TabContent = ({
 const AssistantInfo = () => {
   const navigate = useNavigate(); // useNavigate()를 통해 navigate 함수를 가져옴
   const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
+  const navigationType = useNavigationType(); // 현재 내비게이션 타입 확인
 
   const [dialogType, setDialogType] =
     useState<CounselAssistantDialogTypes>(null); // modalType을 상태로 관리
   const [openIndependentInfoTab, setOpenIndependentInfoTab] = useState(false); // openIndependentInfoTab을 상태로 관리
-
-  const { activeTab } = useAssistantInfoTabStore(); // activeTab을 상태로 관리
-  const detail = useDetailCounselSessionStore((state) => state?.detail); // 상담 세션 정보 조회
+  // activeTab을 상태로 관리
+  const { activeTab } = useAssistantInfoTabStore();
   // 내담자 정보 초기화
   const resetDetail = useDetailCounselSessionStore(
     (state) => state.resetDetail,
   );
+  // 상담 카드 담기
+  const setCounselAssistant = useCounselAssistantStore(
+    (state) => state.setCounselAssistant,
+  );
+
   // 내담자 정보 조회
-  const { data } = useSelectCounseleeInfo(
-    counselSessionId ? detail?.counselSessionId ?? '' : '',
+  const { data: selectCounseleeInfo } = useSelectCounseleeInfo(
+    counselSessionId ?? '',
+  );
+  // 상담 카드 조회
+  const { data: selectCounselCardAssistantInfo } = useSelectCounselCard(
+    counselSessionId ?? '',
   );
   // openModal, closeModal 함수
   const openModal = (type: CounselAssistantDialogTypes) => setDialogType(type);
@@ -98,12 +112,20 @@ const AssistantInfo = () => {
 
   // data.isDisability이 true일 경우 openIndependentInfoTab을 true로 변경
   useEffect(() => {
-    if (data?.isDisability === true) {
+    if (selectCounseleeInfo?.isDisability === true) {
       setOpenIndependentInfoTab(true);
     } else {
       setOpenIndependentInfoTab(false);
     }
-  }, [data, detail, counselSessionId]);
+  }, [selectCounseleeInfo, counselSessionId]);
+
+  useEffect(() => {
+    if (selectCounselCardAssistantInfo) {
+      setCounselAssistant(selectCounselCardAssistantInfo);
+    } else {
+      setCounselAssistant({} as counselAssistantType);
+    }
+  }, [selectCounselCardAssistantInfo, counselSessionId, setCounselAssistant]);
 
   return (
     <div>

--- a/src/pages/assistant/AssistantInfo.tsx
+++ b/src/pages/assistant/AssistantInfo.tsx
@@ -105,15 +105,17 @@ const AssistantInfo = () => {
     resetDetail(); // detail 초기화
   };
 
-  // data.isDisability이 true일 경우 openIndependentInfoTab을 true로 변경
+  // 자립생활 역량 탭 활성화 여부 설정
   useEffect(() => {
     if (selectCounseleeInfo?.isDisability === true) {
       setOpenIndependentInfoTab(true);
     } else {
       setOpenIndependentInfoTab(false);
-      setActiveTab(AssistantInfoTab.basicInfo); // 기본 정보 탭으로 설정
+      if (activeTab === AssistantInfoTab.independentInfo) {
+        setActiveTab(AssistantInfoTab.basicInfo); // 기본 탭으로 변경
+      }
     }
-  }, [selectCounseleeInfo, counselSessionId, setActiveTab]);
+  }, [selectCounseleeInfo, counselSessionId, setActiveTab, activeTab]);
 
   useEffect(() => {
     if (selectCounselCardAssistantInfo) {

--- a/src/pages/assistant/AssistantInfo.tsx
+++ b/src/pages/assistant/AssistantInfo.tsx
@@ -54,11 +54,7 @@ const TabContent = ({
   activeTab: AssistantInfoTab;
   openIndependentInfoTab: boolean;
 }) => {
-  const defaultTab = openIndependentInfoTab ? (
-    <BaseInfo />
-  ) : (
-    <IndependentInfo />
-  );
+  const defaultTab = <BaseInfo />;
 
   switch (activeTab) {
     case AssistantInfoTab.basicInfo:
@@ -68,7 +64,7 @@ const TabContent = ({
     case AssistantInfoTab.lifeInfo:
       return <LifeInfo />;
     case AssistantInfoTab.independentInfo:
-      return <IndependentInfo />;
+      return openIndependentInfoTab ? <IndependentInfo /> : <BaseInfo />;
     default:
       return defaultTab;
   }
@@ -82,7 +78,7 @@ const AssistantInfo = () => {
     useState<CounselAssistantDialogTypes>(null); // modalType을 상태로 관리
   const [openIndependentInfoTab, setOpenIndependentInfoTab] = useState(false); // openIndependentInfoTab을 상태로 관리
   // activeTab을 상태로 관리
-  const { activeTab } = useAssistantInfoTabStore();
+  const { activeTab, setActiveTab } = useAssistantInfoTabStore();
   // 내담자 정보 초기화
   const resetDetail = useDetailCounselSessionStore(
     (state) => state.resetDetail,
@@ -115,8 +111,9 @@ const AssistantInfo = () => {
       setOpenIndependentInfoTab(true);
     } else {
       setOpenIndependentInfoTab(false);
+      setActiveTab(AssistantInfoTab.basicInfo); // 기본 정보 탭으로 설정
     }
-  }, [selectCounseleeInfo, counselSessionId]);
+  }, [selectCounseleeInfo, counselSessionId, setActiveTab]);
 
   useEffect(() => {
     if (selectCounselCardAssistantInfo) {

--- a/src/pages/assistant/AssistantInfo.tsx
+++ b/src/pages/assistant/AssistantInfo.tsx
@@ -10,7 +10,7 @@ import IndependentInfo from '@/pages/assistant/tabs/IndependentInfo';
 import { useEffect, useState } from 'react';
 import { useDetailCounselSessionStore } from '@/store/counselSessionStore';
 import { useSelectCounseleeInfo } from '@/hooks/useCounseleeQuery';
-import { useNavigate, useNavigationType, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { CounselAssistantDialogTypes } from './constants/modal';
 import SaveCounselAsstaint from './dialogs/SaveCounselAsstaint';
 import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
@@ -77,7 +77,6 @@ const TabContent = ({
 const AssistantInfo = () => {
   const navigate = useNavigate(); // useNavigate()를 통해 navigate 함수를 가져옴
   const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
-  const navigationType = useNavigationType(); // 현재 내비게이션 타입 확인
 
   const [dialogType, setDialogType] =
     useState<CounselAssistantDialogTypes>(null); // modalType을 상태로 관리

--- a/src/pages/assistant/dialogs/Index.tsx
+++ b/src/pages/assistant/dialogs/Index.tsx
@@ -54,7 +54,7 @@ const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
       // addCounselAgree.mutate로 요청 실행
       putCounselAgree.mutate(requestBody, {
         onSuccess: () => {
-          navigate('/assistant/info');
+          navigate(`/assistant/${detail?.counselSessionId}`);
         }, // 성공 시 이동
       });
     } else {
@@ -66,7 +66,7 @@ const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
       // addCounselAgree.mutate로 요청 실행
       addCounselAgree.mutate(requestBody, {
         onSuccess: () => {
-          navigate('/assistant/info');
+          navigate(`/assistant/${detail?.counselSessionId}`);
         }, // 성공 시 이동
       });
     }

--- a/src/pages/assistant/dialogs/SaveCounselAsstaint.tsx
+++ b/src/pages/assistant/dialogs/SaveCounselAsstaint.tsx
@@ -13,7 +13,6 @@ import { useDetailCounselSessionStore } from '@/store/counselSessionStore';
 import { useCounselAssistantStore } from '@/store/counselAssistantStore';
 import {
   usePostCounselAssistant,
-  useSelectCounselCard,
   useUpdateCounselAssistant,
 } from '@/hooks/useCounselAssistantQuery';
 import {
@@ -34,9 +33,6 @@ const SaveCounselAssistant = ({
   const navigate = useNavigate();
   const { counselSessionId } = useParams();
   const detail = useDetailCounselSessionStore((state) => state.detail);
-  const selectCounselCard = useSelectCounselCard(
-    detail?.counselSessionId || '',
-  );
   const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
   const updateCounselAssistant = useUpdateCounselAssistant();
   const addCounselCard = usePostCounselAssistant();
@@ -55,11 +51,11 @@ const SaveCounselAssistant = ({
       livingInformation: counselAssistant?.livingInformation || undefined,
       independentLifeInformation:
         counselAssistant?.independentLifeInformation || undefined,
-      counselCardId: selectCounselCard.data?.counselCardId || '',
+      counselCardId: counselAssistant?.counselCardId || '',
       counselSessionId: counselSessionId || detail?.counselSessionId || '',
     };
     // counselCardId가 있으면 업데이트, 없으면 추가
-    if (selectCounselCard.data?.counselCardId) {
+    if (counselAssistant?.counselCardId) {
       updateCounselAssistant.mutate(requestBody, {
         onSuccess: () => {
           if (isTempSave) {
@@ -70,8 +66,7 @@ const SaveCounselAssistant = ({
           }
         },
         onError: (error) => {
-          console.error('Failed to update counsel card:', error);
-          window.alert('상담 카드 업데이트에 실패했습니다.');
+          window.alert('상담 카드 임시저장에 실패했습니다.' + error);
         },
       });
     } else {
@@ -84,8 +79,7 @@ const SaveCounselAssistant = ({
           }
         },
         onError: (error) => {
-          console.error('Failed to add new counsel card:', error);
-          window.alert('상담 카드 등록에 실패했습니다.');
+          window.alert('상담 카드 등록에 실패했습니다.' + error);
         },
       });
     }

--- a/src/pages/assistant/tabs/BaseInfo.tsx
+++ b/src/pages/assistant/tabs/BaseInfo.tsx
@@ -9,37 +9,33 @@ import { useAppDispatch } from '@/app/reduxHooks';
 import CardContainer from '@/components/common/CardContainer';
 import { changeActiveTab } from '@/reducers/tabReducer';
 import { useCounselAssistantStore } from '@/store/counselAssistantStore';
-import { BaseInfoDTOHealthInsuranceTypeEnum, BaseInformationDTO } from '@/api';
+import { BaseInformationDTO } from '@/api';
 import {
   insuranceTypes,
   consultationCounts,
   consultationGoals,
 } from '@/pages/assistant/constants/baseInfo';
+import { useParams } from 'react-router-dom';
+import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
 
 const BaseInfo = () => {
   // 새로고침이 되었을 때도 active tab 을 잃지 않도록 컴포넌트 load 시 dispatch
   const dispatch = useAppDispatch();
-  const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
   useEffect(() => {
     dispatch(changeActiveTab('/assistant/view/basicInfo')); // 해당 tab의 url
   }, [dispatch]);
+  const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
 
+  const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
+  // 상담 카드 조회
+  const { data: selectCounselCardAssistantInfo } = useSelectCounselCard(
+    counselSessionId ?? '',
+  );
   const [formData, setFormData] = useState<BaseInformationDTO>(
     counselAssistant.baseInformation || {
-      version: '1.1',
-      baseInfo: {
-        name: '',
-        birthDate: '',
-        healthInsuranceType: BaseInfoDTOHealthInsuranceTypeEnum.HealthInsurance,
-        counselSessionOrder: '1회차',
-        lastCounselDate: '',
-      },
-      counselPurposeAndNote: {
-        counselPurpose: [],
-        SignificantNote: '',
-        MedicationNote: '',
-      },
-    },
+      baseInfo: {},
+      counselPurposeAndNote: {},
+    }, //counselAssistant.baseInformation이 null이면 빈 객체를 넣어줌),
   );
 
   const toggleGoal = (goal: string) => {
@@ -71,6 +67,12 @@ const BaseInfo = () => {
     }));
   };
 
+  useEffect(() => {
+    if (selectCounselCardAssistantInfo?.baseInformation) {
+      setFormData(selectCounselCardAssistantInfo.baseInformation);
+    }
+  }, [selectCounselCardAssistantInfo, setCounselAssistant, counselSessionId]);
+
   // `formData`가 변경되었을 때 `counselAssistant` 업데이트
   useEffect(() => {
     if (
@@ -83,7 +85,6 @@ const BaseInfo = () => {
       });
     }
   }, [formData, setCounselAssistant, counselAssistant]);
-
   return (
     <>
       <TabContentContainer>

--- a/src/pages/assistant/tabs/HealthInfo.tsx
+++ b/src/pages/assistant/tabs/HealthInfo.tsx
@@ -13,6 +13,8 @@ import {
   isAllergyTypes,
   isMedicineTypes,
 } from '@/pages/assistant/constants/healthInfo';
+import { useParams } from 'react-router-dom';
+import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
 
 const HealthInfo = () => {
   // 새로고침이 되었을 때도 active tab 을 잃지 않도록 컴포넌트 load 시 dispatch
@@ -20,25 +22,18 @@ const HealthInfo = () => {
   useEffect(() => {
     dispatch(changeActiveTab('/assistant/view/healthInfo')); // 해당 tab의 url
   }, [dispatch]);
+  const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
   const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
+  // 상담 카드 조회
+  const { data: selectCounselCardAssistantInfo } = useSelectCounselCard(
+    counselSessionId ?? '',
+  );
   const [formData, setFormData] = useState<HealthInformationDTO>(
     counselAssistant.healthInformation || {
-      version: '1.1',
-      diseaseInfo: {
-        diseases: [],
-        historyNote: '',
-        mainInconvenienceNote: '',
-      },
-      allergy: {
-        isAllergy: false,
-        allergyNote: '',
-      },
-      medicationSideEffect: {
-        isSideEffect: false,
-        suspectedMedicationNote: '',
-        symptomsNote: '',
-      },
-    },
+      diseaseInfo: {},
+      allergy: {},
+      medicationSideEffect: {},
+    }, //counselAssistant.healthInformation이 없을 경우 초기값
   );
 
   const toggleDisease = (disease: string) => {
@@ -65,6 +60,12 @@ const HealthInfo = () => {
       },
     }));
   };
+
+  useEffect(() => {
+    if (selectCounselCardAssistantInfo?.healthInformation) {
+      setFormData(selectCounselCardAssistantInfo.healthInformation);
+    }
+  }, [selectCounselCardAssistantInfo, setCounselAssistant, counselSessionId]);
 
   // `formData`가 변경되었을 때 `counselAssistant` 업데이트
   useEffect(() => {

--- a/src/pages/assistant/tabs/IndependentInfo.tsx
+++ b/src/pages/assistant/tabs/IndependentInfo.tsx
@@ -22,32 +22,26 @@ import {
   IndependentLifeInformationDTO,
   WalkingDTO,
 } from '@/api';
+import { useParams } from 'react-router-dom';
+import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
 
 const IndependentInfo = () => {
   // 새로고침이 되었을 때도 active tab 을 잃지 않도록 컴포넌트 load 시 dispatch
   const dispatch = useAppDispatch();
+  const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
   const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
   useEffect(() => {
     dispatch(changeActiveTab('/assistant/view/livingInfo')); // 해당 tab의 url
   }, [dispatch]);
+  // 상담 카드 조회
+  const { data: selectCounselCardAssistantInfo } = useSelectCounselCard(
+    counselSessionId ?? '',
+  );
   const [formData, setFormData] = useState<IndependentLifeInformationDTO>(
     counselAssistant.independentLifeInformation || {
-      version: '1.1',
-      walking: {
-        walkingMethods: [],
-        walkingEquipments: [],
-        etcNote: '',
-      },
-      evacuation: {
-        evacuationMethods: [],
-        etcNote: '',
-      },
-      communication: {
-        sights: [],
-        hearings: [],
-        communications: [],
-        usingKoreans: [],
-      },
+      walking: {},
+      evacuation: {},
+      communication: {},
     },
   );
   const handleOptionChange = (
@@ -102,6 +96,13 @@ const IndependentInfo = () => {
       },
     }));
   };
+
+  useEffect(() => {
+    if (selectCounselCardAssistantInfo?.independentLifeInformation) {
+      setFormData(selectCounselCardAssistantInfo.independentLifeInformation);
+    }
+  }, [selectCounselCardAssistantInfo, setCounselAssistant, counselSessionId]);
+
   // `formData`가 변경되었을 때 `counselAssistant` 업데이트
   useEffect(() => {
     if (

--- a/src/pages/assistant/tabs/LifeInfo.tsx
+++ b/src/pages/assistant/tabs/LifeInfo.tsx
@@ -18,40 +18,29 @@ import {
   dailyEatingTypes,
   exerciseWeeklyCounts,
 } from '@/pages/assistant/constants/lifeInfo';
+import { useParams } from 'react-router-dom';
+import { useSelectCounselCard } from '@/hooks/useCounselAssistantQuery';
 
 const LifeInfo = () => {
   // 새로고침이 되었을 때도 active tab 을 잃지 않도록 컴포넌트 load 시 dispatch
   const dispatch = useAppDispatch();
+  const { counselSessionId } = useParams(); //useParams()를 통해 counselSessionId를 가져옴
   const { counselAssistant, setCounselAssistant } = useCounselAssistantStore();
   useEffect(() => {
     dispatch(changeActiveTab('/assistant/view/lifeInfo')); // 해당 tab의 url
   }, [dispatch]);
+  // 상담 카드 조회
+  const { data: selectCounselCardAssistantInfo } = useSelectCounselCard(
+    counselSessionId ?? '',
+  );
   const [formData, setFormData] = useState<LivingInformationDTO>(
     counselAssistant.livingInformation || {
-      version: '1.1',
-      smoking: {
-        isSmoking: false,
-        smokingAmount: '',
-        smokingPeriodNote: '',
-      },
-      drinking: {
-        isDrinking: false,
-        drinkingAmount: '',
-      },
-      nutrition: {
-        mealPattern: '',
-        nutritionNote: '',
-      },
-      exercise: {
-        exercisePattern: '',
-        exerciseNote: '',
-      },
-      medicationManagement: {
-        isAlone: false,
-        houseMateNote: '',
-        medicationAssistants: [],
-      },
-    },
+      smoking: {},
+      drinking: {},
+      nutrition: {},
+      exercise: {},
+      medicationManagement: {},
+    }, //counselAssistant.livingInformation이 null이면 빈 객체를 넣어줌
   );
 
   const toggleGoal = (member: string) => {
@@ -84,6 +73,12 @@ const LifeInfo = () => {
       },
     }));
   };
+
+  useEffect(() => {
+    if (selectCounselCardAssistantInfo?.livingInformation) {
+      setFormData(selectCounselCardAssistantInfo.livingInformation);
+    }
+  }, [selectCounselCardAssistantInfo, setCounselAssistant, counselSessionId]);
 
   // `formData`가 변경되었을 때 `counselAssistant` 업데이트
   useEffect(() => {

--- a/src/store/assistantTabStore.ts
+++ b/src/store/assistantTabStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export enum AssistantInfoTab {
   basicInfo = 'basicInfo',
@@ -11,10 +12,17 @@ interface AssistantInfoTabState {
   activeTab: AssistantInfoTab;
   setActiveTab: (tab: AssistantInfoTab) => void;
 }
-
-const useAssistantInfoTabStore = create<AssistantInfoTabState>((set) => ({
-  activeTab: AssistantInfoTab.basicInfo,
-  setActiveTab: (tab: AssistantInfoTab) => set({ activeTab: tab }),
-}));
+const useAssistantInfoTabStore = create<AssistantInfoTabState>()(
+  persist(
+    (set) => ({
+      activeTab: AssistantInfoTab.basicInfo,
+      setActiveTab: (tab: AssistantInfoTab) => set({ activeTab: tab }),
+    }),
+    {
+      name: 'active-tab-storage', // localStorage key
+      storage: createJSONStorage(() => localStorage), // 저장소 설정 (localStorage 사용)
+    },
+  ),
+);
 
 export default useAssistantInfoTabStore;

--- a/src/store/counselAssistantStore.ts
+++ b/src/store/counselAssistantStore.ts
@@ -82,11 +82,11 @@ export const useCounselAssistantStore = create<CounselAssistantState>()(
           nutritionNote: '',
         },
         exercise: {
-          exercisePattern: '',
+          exercisePattern: '운동 안 함',
           exerciseNote: '',
         },
         medicationManagement: {
-          isAlone: false,
+          isAlone: true,
           houseMateNote: '',
           medicationAssistants: [],
         },


### PR DESCRIPTION
1. fix: 🐛 내담자 정보 조회활용 이전 정보 불러오기
2. fix: 🐛 의존성 배열 값 수정에 따른 Dialog 오픈 에러 수정
3. fix: 🐛 fix eslint error
4. fix: 🐛 정보 동의 제공후 counselSessinoId 로 동적 파라미터 설정
5. fix: 🐛 상담카드 저장 및 임시저장 로직 수정
6. fix: 🐛 탭 이동 버그 수정
7. feat: ✨ persist활용 새로고침후 탭 유지