### PR TITLE
fix: 🐛 초기 상담 설문 페이지 수정 Ver1.3

### DIFF
--- a/src/pages/Home/components/SurveyDialog.tsx
+++ b/src/pages/Home/components/SurveyDialog.tsx
@@ -13,6 +13,8 @@ import { XIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AddCounselCardReqCardRecordStatusEnum } from '@/api/api';
+import { useCounseleeConsentQueryId } from '@/pages/Survey/hooks/useCounselAgreeQuery';
+import UserInfoDialog from '@/pages/Survey/dialogs/userInfo/Index';
 import { useDetailCounselSessionStore } from '@/store/counselSessionStore';
 
 interface SurveyDialogProps {
@@ -28,16 +30,36 @@ function SurveyDialog({
 }: SurveyDialogProps) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const [isUserInfoOpen, setIsUserInfoOpen] = useState(false);
+
+  // 내담자 개인정보 수집 동의 여부 조회
+  const { data, isLoading } = useCounseleeConsentQueryId(
+    counselSessionId || undefined,
+    counseleeId || undefined,
+    !!open,
+  );
+  // 상담 세션 상세 정보 조회
   const { setDetail } = useDetailCounselSessionStore();
+
+  // 작성하기 버튼 클릭시
   const handleStartSurvey = () => {
-    setDetail({ counseleeId });
-    navigate(`/survey/${counselSessionId}`);
+    setDetail({ counselSessionId, counseleeId });
+
+    if (!isLoading && data) {
+      // 동의 한사람인 경우 기초 설문 작성 페이지로 이동
+      if (data.status === 200 && data.data.data?.isConsent === true) {
+        navigate(`/survey/${counselSessionId}`);
+      } else {
+        // 동의하지 않은 사람인 경우 동의 페이지로 이동
+        setIsUserInfoOpen(true);
+      }
+    }
   };
 
   const buttonConfig = {
     [AddCounselCardReqCardRecordStatusEnum.Unrecorded]: {
       variant: 'primary' as const,
-      text: '카드 작성',
+      text: '설문 작성',
     },
     [AddCounselCardReqCardRecordStatusEnum.Recording]: {
       variant: 'secondary' as const,
@@ -59,38 +81,46 @@ function SurveyDialog({
   );
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{renderTriggerButton()}</DialogTrigger>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>기초 설문을 작성하시겠어요?</DialogTitle>
-          <DialogClose
-            asChild
-            className="cursor-pointer border-none bg-transparent text-grayscale-100 !mt-0 !p-0 w-6 h-6">
-            <XIcon />
-          </DialogClose>
-        </DialogHeader>
-        <div className="h-[1px] bg-grayscale-20" />
-        <DialogDescription className="sm:justify-start">
-          상담 경험이 있는 내담자는 이전 기록이 적혀 있습니다.
-        </DialogDescription>
-        <DialogFooter className="sm:justify-end">
-          <div>
-            <DialogClose asChild>
-              <Button variant="secondary" className="mx-[0.5rem]">
-                취소
-              </Button>
+    <div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{renderTriggerButton()}</DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>기초 설문을 작성하시겠어요?</DialogTitle>
+            <DialogClose
+              asChild
+              className="cursor-pointer border-none bg-transparent text-grayscale-100 !mt-0 !p-0 w-6 h-6">
+              <XIcon />
             </DialogClose>
-            <Button
-              variant="primary"
-              className="mx-[0.5rem]"
-              onClick={handleStartSurvey}>
-              작성하기
-            </Button>
-          </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          </DialogHeader>
+          <div className="h-[1px] bg-grayscale-20" />
+          <DialogDescription className="sm:justify-start">
+            상담 경험이 있는 내담자는 이전 기록이 적혀 있습니다.
+          </DialogDescription>
+          <DialogFooter className="sm:justify-end">
+            <div>
+              <DialogClose asChild>
+                <Button variant="secondary" className="mx-[0.5rem]">
+                  취소
+                </Button>
+              </DialogClose>
+              <Button
+                variant="primary"
+                className="mx-[0.5rem]"
+                onClick={handleStartSurvey}>
+                작성하기
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <UserInfoDialog
+        isOpen={isUserInfoOpen}
+        handleOpen={() => setIsUserInfoOpen(!isUserInfoOpen)}
+        counselSessionId={counselSessionId}
+        counseleeId={counseleeId}
+      />
+    </div>
   );
 }
 

--- a/src/pages/Survey/constants/baseInfo/index.ts
+++ b/src/pages/Survey/constants/baseInfo/index.ts
@@ -20,24 +20,12 @@ export const insuranceTypes = [
 ];
 export const consultationCounts = [
   {
-    value: '1회차',
-    label: '1회차',
+    value: '초기상담',
+    label: '초기상담',
   },
   {
-    value: '2회차',
-    label: '2회차',
-  },
-  {
-    value: '3회차',
-    label: '3회차',
-  },
-  {
-    value: '4회차',
-    label: '4회차',
-  },
-  {
-    value: '5회차 이상',
-    label: '5회차 이상',
+    value: '재상담',
+    label: '재상담',
   },
 ];
 export const consultationGoals = [

--- a/src/pages/Survey/dialogs/userInfo/ExpiredMedications.tsx
+++ b/src/pages/Survey/dialogs/userInfo/ExpiredMedications.tsx
@@ -2,7 +2,6 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
-  DialogOverlay,
   DialogTitle,
 } from '@/components/ui/dialog';
 import arrowForwardIcon from '@/assets/icon/24/arrowback.outlined.black.svg';
@@ -20,7 +19,6 @@ const ExpiredMedications = ({
 }: AgreementDetailDialogTypes) => {
   return (
     <Dialog open={isDetailOpen} onOpenChange={onClose}>
-      <DialogOverlay />
       <DialogContent className="h-[170px] w-[480px]">
         <DialogHeader className="justify-normal">
           <img

--- a/src/pages/Survey/dialogs/userInfo/Index.tsx
+++ b/src/pages/Survey/dialogs/userInfo/Index.tsx
@@ -8,78 +8,87 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import InformationUse from '@/pages/Survey/dialogs/userInfo/InformationUse';
 import InformationThirdParties from '@/pages/Survey/dialogs/userInfo/InformationThirdParties';
 import ExpiredMedications from '@/pages/Survey/dialogs/userInfo/ExpiredMedications';
 import {
   useCounseleeConsentQueryId,
   usePostCounselAgree,
-  usePutCounselAgree,
 } from '@/pages/Survey/hooks/useCounselAgreeQuery';
 import { useDetailCounselSessionStore } from '@/store/counselSessionStore';
-import { useCounselAgreeSessionStore } from '@/store/counselAgreeStore';
 
 type MainDialogTypes = {
   isOpen: boolean;
   handleOpen: () => void;
+  counselSessionId: string;
+  counseleeId: string;
 };
 
-const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
+const Index = ({
+  isOpen,
+  handleOpen,
+  counselSessionId,
+  counseleeId,
+}: MainDialogTypes) => {
   const navigate = useNavigate();
   const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
   const [isDetails2DialogOpen, setIsDetails2DialogOpen] = useState(false);
   const [isDetails3DialogOpen, setIsDetails3DialogOpen] = useState(false);
-  const detail = useDetailCounselSessionStore((state) => state.detail);
-  const putCounselAgree = usePutCounselAgree();
-  const counseleeConsent = useCounselAgreeSessionStore(
-    (state) => state.counseleeConsent || '',
-  );
+  const [onceFetched, setOnceFetched] = useState(false);
+
   // 내담자 개인정보 수집 동의 여부 조회
   const { data } = useCounseleeConsentQueryId(
-    detail?.counselSessionId || undefined,
-    detail?.counseleeId || undefined,
-    !!detail,
+    counselSessionId || undefined,
+    counseleeId || undefined,
+    !onceFetched && isOpen,
   );
+  // 상담 세션 상세 정보 조회
+  const { setDetail } = useDetailCounselSessionStore();
 
   // 내담자 개인정보 수집 동의 여부 등록 API 연결
   const addCounselAgree = usePostCounselAgree();
 
   // 전부 동의하고 시작하기 버튼 클릭 시
   const handleAllAgree = () => {
+    setDetail({ counselSessionId, counseleeId });
     // data.status가 204일 경우
     if (data?.status === 204) {
       const requestBody = {
-        counselSessionId: detail?.counselSessionId || '',
-        counseleeId: detail?.counseleeId || '',
+        counselSessionId: counselSessionId || '',
+        counseleeId: counseleeId || '',
         consent: true,
       };
       // addCounselAgree.mutate로 요청 실행
       addCounselAgree.mutate(requestBody, {
         onSuccess: () => {
-          navigate(`/survey/${detail?.counselSessionId}`);
-        }, // 성공 시 이동
-      });
-    } else {
-      // data.status가 200일 경우
-      const requestBody = {
-        counseleeConsentId: counseleeConsent.counseleeConsentId,
-        consent: true,
-      };
-      // putCounselAgree.mutate로 요청 실행
-      putCounselAgree.mutate(requestBody, {
-        onSuccess: () => {
-          navigate(`/survey/${detail?.counselSessionId}`);
+          navigate(`/survey/${counselSessionId}`);
         }, // 성공 시 이동
       });
     }
   };
+
+  // 서브 다이얼로그를 열면서 메인 다이얼로그를 닫는 함수
+  const openSubDialog = (
+    setSubDialogOpen: Dispatch<SetStateAction<boolean>>,
+  ) => {
+    handleOpen(); // 메인 다이얼로그 닫기
+    setSubDialogOpen(true); // 서브 다이얼로그 열기
+  };
+
+  // isOpen이 true가 되면 한 번만 실행되도록 설정
+  useEffect(() => {
+    if (isOpen && !onceFetched) {
+      setOnceFetched(true);
+    }
+  }, [isOpen, onceFetched]);
+
   return (
     <>
       <Dialog open={isOpen} onOpenChange={handleOpen}>
         <DialogContent className="w-[480px] h-[375px] pt-10 pl-5 pr-5 ">
           <DialogHeader className="mx-0 leading-10 mb-9 text-grayscale-100 ">
-            <DialogTitle className="flex pl-3 pr-3 text-[1.75rem] font-bold leading-9">
+            <DialogTitle className="flex pl-3 pr-3 text-[28px] font-bold leading-9">
               개인정보 수집 동의서를
               <br />
               작성해주세요.
@@ -89,10 +98,7 @@ const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
           <div className="flex flex-col gap-4 p-5 mx-auto mb-5 rounded-lg mt-9 bg-grayscale-3">
             <div
               className="flex items-center justify-between cursor-pointer "
-              onClick={() => {
-                setIsDetailsDialogOpen(true);
-                handleOpen();
-              }}>
+              onClick={() => openSubDialog(setIsDetailsDialogOpen)}>
               <h2 className="ml-2 text-grayscale-90">
                 개인정보 수집 · 이용 내역 동의
               </h2>
@@ -103,10 +109,7 @@ const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
             </div>
             <div
               className="flex items-center justify-between cursor-pointer"
-              onClick={() => {
-                setIsDetails2DialogOpen(true);
-                handleOpen();
-              }}>
+              onClick={() => openSubDialog(setIsDetails2DialogOpen)}>
               <h2 className="ml-2 text-grayscale-90">
                 개인정보의 제 3자 제공 동의
               </h2>
@@ -118,10 +121,7 @@ const Index = ({ isOpen, handleOpen }: MainDialogTypes) => {
             </div>
             <div
               className="flex items-center justify-between cursor-pointer"
-              onClick={() => {
-                setIsDetails3DialogOpen(true);
-                handleOpen();
-              }}>
+              onClick={() => openSubDialog(setIsDetails3DialogOpen)}>
               <h2 className="ml-2 text-grayscale-90">
                 폐의약품 수거에 관한 동의
               </h2>

--- a/src/pages/Survey/tabs/BaseInfo.tsx
+++ b/src/pages/Survey/tabs/BaseInfo.tsx
@@ -293,9 +293,9 @@ const BaseInfo = () => {
               'healthInsuranceType',
             )}
 
-            {/* 상담차수  */}
+            {/* 상담경험  */}
             {renderButtons(
-              '상담차수',
+              '상담경험',
               consultationCounts,
               'baseInfo',
               'counselSessionOrder',


### PR DESCRIPTION
1. fix: 🐛  기초 설문 페이지 컬럼명 상담차수 -> 상담 경험 네이밍 변경
2. fix: 🐛 폐의약품 수거 Dialog에서  <DialogOverlay /> 제거
3. fix: 🐛 기초 상담 카드 -> 기초 설문 변경 , 리스트에서 상담 동의 여부 조회 제거
4. fix: 🐛 다이얼로그 메인 타이블 폰트 크기 변경 & onceFetched통해 isOpen이 true가 되면 한 번만 실행되도록 설정
5. fix: 🐛 카드 작성 -> 설문 작성으로 변경, SurveyDialog에서 작성하기 버튼 클릭시 동작함수 추가