### PR TITLE
refactor: 이전 상담내역 탭 재활성화

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,6 @@
   "arrowParens": "always",
   "endOfLine": "lf",
   "bracketSameLine": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "postcss": "^8.5.3",
+    "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "rollup-plugin-visualizer": "^5.14.0",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,12 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
+      prettier:
+        specifier: ^3.5.3
+        version: 3.5.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.11
+        version: 0.6.11(prettier@3.5.3)
       rollup-plugin-visualizer:
         specifier: ^5.14.0
         version: 5.14.0(rollup@4.34.8)
@@ -2849,6 +2855,66 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.6.11:
+    resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
@@ -6258,6 +6324,12 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.3):
+    dependencies:
+      prettier: 3.5.3
+
+  prettier@3.5.3: {}
 
   promise@7.3.1:
     dependencies:

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -2,7 +2,11 @@ import { BrowserRouter } from 'react-router-dom';
 import Routes from './Routes';
 const Router = () => {
   return (
-    <BrowserRouter>
+    <BrowserRouter
+      future={{
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      }}>
       <Routes />
     </BrowserRouter>
   );

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mb-10 pt-6 pb-10 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 overflow-y-auto mx-auto w-full max-w-layout px-layout [&>*]:max-w-content [&>*]:mx-auto',
+      'mb-10 pt-10 pb-10 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 overflow-y-auto mx-auto w-full max-w-layout px-layout [&>*]:max-w-content [&>*]:mx-auto',
       className,
     )}
     {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex h-full items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 hover:border-b-2 hover:border-grayscale-20 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary-50 data-[state=active]:shadow-sm data-[state=active]:border-b-2 data-[state=active]:border-b-primary-50 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 dark:data-[state=active]:bg-neutral-950 dark:data-[state=active]:text-neutral-50',
+      'inline-flex h-full items-center justify-center whitespace-nowrap border-b-2 border-transparent text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 hover:border-b-2 hover:border-grayscale-20 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-primary-50 data-[state=active]:shadow-sm data-[state=active]:border-b-2 data-[state=active]:border-b-primary-50 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 dark:data-[state=active]:bg-neutral-950 dark:data-[state=active]:text-neutral-50',
       className,
     )}
     {...props}

--- a/src/pages/Consult/components/table/PrevCounselTable/index.tsx
+++ b/src/pages/Consult/components/table/PrevCounselTable/index.tsx
@@ -1,0 +1,22 @@
+import { DataTable } from '@/components/common/DataTable/data-table';
+import { createColumns } from '@/pages/Consult/components/table/PrevCounselTable/prevCounselTableColunm';
+import { usePrevCounselSessionList } from '@/pages/Consult/hooks/query/usePrevCounselSessionList';
+import { useParams } from 'react-router-dom';
+
+function PrevCounselTable() {
+  const { counselSessionId } = useParams();
+
+  const { prevCounselSessionList, isLoading } = usePrevCounselSessionList(
+    counselSessionId ?? '',
+  );
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  const columns = createColumns();
+
+  return <DataTable columns={columns} data={prevCounselSessionList} />;
+}
+
+export default PrevCounselTable;

--- a/src/pages/Consult/components/table/PrevCounselTable/prevCounselTableColunm.tsx
+++ b/src/pages/Consult/components/table/PrevCounselTable/prevCounselTableColunm.tsx
@@ -1,0 +1,29 @@
+import { PrevCounselSessionListDTO } from '@/pages/Consult/hooks/query/usePrevCounselSessionList';
+import { ColumnDef } from '@tanstack/react-table';
+
+export const createColumns = (): ColumnDef<PrevCounselSessionListDTO>[] => {
+  return [
+    {
+      header: '상담횟수',
+      accessorKey: 'CounselSessionOrder',
+      cell: ({ row }) => {
+        return `${row.original.CounselSessionOrder}회차`;
+      },
+    },
+    {
+      header: '상담일자',
+      accessorKey: 'counselSessionDate',
+    },
+    {
+      header: '담당약사',
+      accessorKey: 'counselorName',
+    },
+    {
+      header: '케어링메세지',
+      accessorKey: 'isShardCaringMessage',
+      cell: ({ row }) => {
+        return row.original.isShardCaringMessage ? '공유완료' : '공유대기';
+      },
+    },
+  ];
+};

--- a/src/pages/Consult/components/tabs/PastConsult.tsx
+++ b/src/pages/Consult/components/tabs/PastConsult.tsx
@@ -1,108 +1,57 @@
-// import {
-//   CounselSessionControllerApi,
-//   MedicationCounselControllerApi,
-// } from '@/api';
-// import PastConsultContainer from '@/components/consult/PastConsultContainer';
-// import { Card, CardHeader, CardTitle } from '@/components/ui/card';
-// import { useQuery } from '@tanstack/react-query';
-// import moment from 'moment';
-// import React from 'react';
-// import { useParams } from 'react-router-dom';
+import PastConsultContainer from '@/components/consult/PastConsultContainer';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import PrevCounselTable from '@/pages/Consult/components/table/PrevCounselTable';
+import { usePrevMedicationCounsel } from '@/pages/Consult/hooks/query/usePrevMedicationCounsel';
 
-// const PastConsult: React.FC = () => {
-//   const { counselSessionId } = useParams();
+import React from 'react';
+import { useParams } from 'react-router-dom';
 
-//   // TODO: 쿼리 커스텀 훅 분리 및 데이터 store set init 로직 개선 필요
-//   const counselSessionControllerApi = new CounselSessionControllerApi();
-//   const medicationCounselControllerApi = new MedicationCounselControllerApi();
+const PastConsult: React.FC = () => {
+  const { counselSessionId } = useParams();
 
-//   const selectPreviousMedicationCounsel = async () => {
-//     if (!counselSessionId) return;
-//     const response =
-//       await medicationCounselControllerApi.selectPreviousMedicationCounsel(
-//         counselSessionId,
-//       );
+  const { prevMedicationCounsel } = usePrevMedicationCounsel(counselSessionId);
 
-//     return response;
-//   };
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>이전 상담 내용</CardTitle>
+      </CardHeader>
+      <div className="flex flex-row justify-between items-start space-x-4">
+        <PastConsultContainer title="상담 기록 하이라이트" variant="primary">
+          <ul className="mt-4 text-body1 font-medium space-y-2">
+            {prevMedicationCounsel?.counselRecordHighlights?.map(
+              (item, index) => {
+                return (
+                  <li
+                    key={index}
+                    className="border-l-2 border-grayscale-10 pl-2">
+                    {item.highlight}
+                  </li>
+                );
+              },
+            )}
+          </ul>
+        </PastConsultContainer>
 
-//   // const columns: GridColDef[] = React.useMemo(
-//   //   () => [
-//   //     {
-//   //       ...createDefaultNumberColumn({
-//   //         field: 'col1',
-//   //         headerName: '상담횟수',
-//   //         unitName: '회차',
-//   //         isFirstColumn: true,
-//   //       }),
-//   //     },
-//   //     {
-//   //       ...createDefaultDateColumn({
-//   //         field: 'col2',
-//   //         headerName: '상담일자',
-//   //       }),
-//   //     },
-//   //     { ...createDefaultTextColumn({ field: 'col3', headerName: '담당약사' }) },
-//   //     {
-//   //       ...createDefaultTextColumn({
-//   //         field: 'col4',
-//   //         headerName: '케어링메세지',
-//   //       }),
-//   //     },
-//   //   ],
-//   //   [],
-//   // );
+        <PastConsultContainer title="상담노트 요약" variant="secondary">
+          <h2 className="text-subtitle2 font-bold text-secondary-70 flex items-center"></h2>
+          <p className="mt-4 whitespace-pre-wrap">
+            {prevMedicationCounsel?.counselNoteSummary}
+          </p>
+        </PastConsultContainer>
+      </div>
 
-//   //const memoizedColumns = React.useMemo(() => columns, [columns]);
+      <CardHeader>
+        <CardTitle>이전 상담 자세히 보기</CardTitle>
+        <p className="text-body1 font-medium text-grayscale-70 !mt-0">
+          케어링 노트로 남긴 이전 회차 상담 목록
+        </p>
+      </CardHeader>
+      <div className="h-auto">
+        <PrevCounselTable />
+      </div>
+    </Card>
+  );
+};
 
-//   return (
-//     <Card>
-//       <CardHeader>
-//         <CardTitle>이전 상담 내용</CardTitle>
-//       </CardHeader>
-//       <div className="flex flex-row justify-between items-start space-x-4">
-//         <PastConsultContainer title="상담 기록 하이라이트" variant="primary">
-//           <ul className="mt-4 text-body1 font-medium space-y-2">
-//             {previousMedicationCounselQuery?.data?.data?.data?.counselRecordHighlights?.map(
-//               (item, index) => {
-//                 return (
-//                   <li
-//                     key={index}
-//                     className="border-l-2 border-grayscale-10 pl-2">
-//                     {item.highlight}
-//                   </li>
-//                 );
-//               },
-//             )}
-//           </ul>
-//         </PastConsultContainer>
-
-//         <PastConsultContainer title="상담노트 요약" variant="secondary">
-//           <h2 className="text-subtitle2 font-bold text-secondary-70 flex items-center"></h2>
-//           <p className="mt-4 whitespace-pre-wrap">
-//             {
-//               previousMedicationCounselQuery?.data?.data?.data
-//                 ?.counselNoteSummary
-//             }
-//           </p>
-//         </PastConsultContainer>
-//       </div>
-
-//       <CardHeader>
-//         <CardTitle>상담 내역</CardTitle>
-//         <p className="text-body1 font-medium text-grayscale-70 !mt-0">
-//           케어링 노트로 남긴 상담 내역이 노출됩니다
-//         </p>
-//       </CardHeader>
-//       <div className="h-auto">
-//         {/* <TableComponent
-//           tableKey={'past-consult'}
-//           rows={pastConsultRows || []}
-//           columns={memoizedColumns}
-//         /> */}
-//       </div>
-//     </Card>
-//   );
-// };
-
-// export default PastConsult;
+export default PastConsult;

--- a/src/pages/Consult/components/tabs/PastConsult.tsx
+++ b/src/pages/Consult/components/tabs/PastConsult.tsx
@@ -14,7 +14,7 @@ const PastConsult: React.FC = () => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>이전 상담 내용</CardTitle>
+        <CardTitle>지난번 상담에서의 핵심 내용</CardTitle>
       </CardHeader>
       <div className="flex flex-row justify-between items-start space-x-4">
         <PastConsultContainer title="상담 기록 하이라이트" variant="primary">

--- a/src/pages/Consult/hooks/query/usePrevCounselSessionList.tsx
+++ b/src/pages/Consult/hooks/query/usePrevCounselSessionList.tsx
@@ -1,0 +1,44 @@
+import { CounselSessionControllerApi } from '@/api';
+import { useQuery } from '@tanstack/react-query';
+import { SelectPreviousCounselSessionListRes } from '@/api/api';
+
+export interface PrevCounselSessionListDTO
+  extends SelectPreviousCounselSessionListRes {
+  id: string | undefined;
+}
+
+const counselSessionControllerApi = new CounselSessionControllerApi();
+
+const getPrevCounselSessionList = async (
+  counselSessionId: string | undefined,
+) => {
+  if (!counselSessionId) return;
+
+  const response =
+    await counselSessionControllerApi.selectPreviousCounselSessionList(
+      counselSessionId,
+    );
+
+  return response.data;
+};
+
+export const usePrevCounselSessionList = (
+  counselSessionId: string | undefined,
+) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['prevCounselSessionList', counselSessionId],
+    queryFn: () => getPrevCounselSessionList(counselSessionId),
+    enabled: !!counselSessionId,
+    select: (data) => {
+      return data?.data?.map((item) => ({
+        ...item,
+        id: item.counselSessionId,
+      }));
+    },
+  });
+
+  return {
+    prevCounselSessionList: data ?? [],
+    isLoading,
+  };
+};

--- a/src/pages/Consult/hooks/query/usePrevMedicationCounsel.tsx
+++ b/src/pages/Consult/hooks/query/usePrevMedicationCounsel.tsx
@@ -1,0 +1,31 @@
+import { MedicationCounselControllerApi } from '@/api';
+import { useQuery } from '@tanstack/react-query';
+
+const medicationCounselControllerApi = new MedicationCounselControllerApi();
+
+const selectPreviousMedicationCounsel = async (
+  counselSessionId: string | undefined,
+) => {
+  if (!counselSessionId) return;
+  const response =
+    await medicationCounselControllerApi.selectPreviousMedicationCounsel(
+      counselSessionId,
+    );
+
+  return response.data;
+};
+
+export const usePrevMedicationCounsel = (
+  counselSessionId: string | undefined,
+) => {
+  const { data, isSuccess } = useQuery({
+    queryKey: ['prevMedicationCounsel', counselSessionId],
+    queryFn: () => selectPreviousMedicationCounsel(counselSessionId),
+    enabled: !!counselSessionId,
+  });
+
+  return {
+    prevMedicationCounsel: data?.data,
+    isSuccess,
+  };
+};

--- a/src/pages/Consult/index.tsx
+++ b/src/pages/Consult/index.tsx
@@ -20,6 +20,7 @@ import ConsultCard from './components/tabs/ConsultCard';
 import DiscardMedicine from './components/tabs/DiscardMedicine';
 import MedicineConsult from './components/tabs/MedicineConsult';
 import MedicineMemo from './components/tabs/MedicineMemo';
+import PastConsult from '@/pages/Consult/components/tabs/PastConsult';
 
 interface InfoItemProps {
   icon: string;
@@ -179,9 +180,9 @@ export function Index() {
           saveConsult={saveConsult}
         />
         <div className="w-full h-full mb-100">
-          {/* <TabsContent value="pastConsult">
+          <TabsContent value="pastConsult">
             <PastConsult />
-          </TabsContent> */}
+          </TabsContent>
           <TabsContent value="survey">
             <ConsultCard />
           </TabsContent>

--- a/src/pages/Consult/index.tsx
+++ b/src/pages/Consult/index.tsx
@@ -97,7 +97,7 @@ const ConsultHeader = ({
 
 const ConsultTabs = () => (
   <TabsList className="w-full border-b border-grayscale-10">
-    <div className="flex gap-5 justify-start max-w-layout px-layout [&>*]:max-w-content mx-auto w-full">
+    <div className="flex gap-5 justify-start max-w-layout h-full px-layout [&>*]:max-w-content mx-auto w-full">
       <TabsTrigger value="pastConsult">이전 상담 내역</TabsTrigger>
       <TabsTrigger value="survey">기초 설문 내역</TabsTrigger>
       <TabsTrigger value="medicine">의약물 기록</TabsTrigger>


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?



- 이전 상답 내역 탭 쿼리 호출 훅 구현, 테이블 마이그레이션

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?



- 이전 상담내역 api 호출 커스텀 훅 추가
- 이전 상담 자세히 보기 테이블 shadcn data table 컴포넌트
- tab content 메뉴 스타일 수정

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- react-router-dom warning resolve를 위한 BrowserRouter features 옵션설정
- tailwind prettier install

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요



-

##### 📌 PR 진행 시 이러한 점들을 참고해 주세요


---

## 📝 Assignee를 위한 CheckList

- [ ] To-Do Item
