### PR TITLE
refactor: :sparkles: 중재기록 작성 init 여부 플래그 추가를 통한 editState 중복 init 방지

### DIFF
--- a/src/store/medicineConsultStore.ts
+++ b/src/store/medicineConsultStore.ts
@@ -4,14 +4,18 @@ import {
   MedicineConsultDTO,
 } from '@/types/MedicineConsultDTO';
 
-export const useMedicineConsultStore = create<{
+interface MedicineConsultState {
   medicineConsult: MedicineConsultDTO;
   setMedicationConsult: (data: MedicineConsultDTO) => void;
   setCounselRecord: (counselRecord: string) => void;
   setCounselRecordHighlights: (
     counselRecordHighlights: CounselRecordHighlights[],
   ) => void;
-}>((set) => ({
+  isEditorInitialized: boolean;
+  setEditorInitialized: (initialized: boolean) => void;
+}
+
+export const useMedicineConsultStore = create<MedicineConsultState>((set) => ({
   medicineConsult: {
     counselSessionId: '',
     medicationCounselId: '',
@@ -38,4 +42,8 @@ export const useMedicineConsultStore = create<{
         counselRecordHighlights,
       },
     })),
+
+  isEditorInitialized: false,
+  setEditorInitialized: (initialized) =>
+    set({ isEditorInitialized: initialized }),
 }));


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- 중재기록 작성의 내용이 재 렌더링시 API에서 불러온 초기값으로 덮어씌워지는 문제 해결

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?


- useMedicineConsultStore init 여부 플래그 추가

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- 없음

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요


##### 📌 PR 진행 시 이러한 점들을 참고해 주세요

```
- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 7일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3, P4, P5 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
    - P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
```

---

## 📝 Assignee를 위한 CheckList

- [ ] To-Do Item
